### PR TITLE
adb: fix the offline error on USB hot-plug

### DIFF
--- a/adb_client.c
+++ b/adb_client.c
@@ -474,6 +474,7 @@ void adb_close_all_service(adb_client_t *client) {
         adb_service_close(client, service, NULL);
         service = next;
     }
+    client->is_connected = 0;
 }
 
 void adb_destroy_client(adb_client_t *client) {

--- a/hal/hal_uv_packet.c
+++ b/hal/hal_uv_packet.c
@@ -189,9 +189,10 @@ void adb_uv_on_data_available(adb_client_uv_t *client, uv_stream_t *stream,
             adb_err("bad header: terminated (data)\n");
 
             /* Removes the first received frame header */
-
-            memcpy(&up->p.msg, &((char*)&up->p.msg)[client->cur_len], nread);
-            client->cur_len = nread;
+            if (client->cur_len != 0) {
+                memcpy(&up->p.msg, &((char*)&up->p.msg)[client->cur_len], nread);
+                client->cur_len = nread;
+            }
             return;
         }
     }


### PR DESCRIPTION
1. Rset is_connected on usb disconnect to ensure the reconnection handshake uses the correct frame validation for CNXN/AUTH packets.
2. Fix the recovery logic bug. It didn't drop the corrupted header when cur_len was 0, causing adb_uv_allocate_frame to use the invalid data_length for buffer size calculation, leading to a write overflow in usbdev_fs_read.
